### PR TITLE
chore: adjust SMS length limits for multipart message support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ A professional Python SDK for sending SMS via the Beem SMS API. This package pro
 
 ## Features
 
-- 🚀 **Easy to use** - Simple, intuitive API
-- 🛡️ **Robust error handling** - Comprehensive exception handling and validation
-- 📱 **Phone number validation** - Built-in phone number validation and formatting
-- 🔄 **Retry logic** - Automatic retry on failures with exponential backoff
-- 📊 **Logging support** - Detailed logging for debugging and monitoring
-- 🎯 **Type hints** - Full type hint support for better IDE experience
-- 🔐 **Security** - Secure credential handling
-- 📦 **Bulk SMS** - Efficient bulk SMS sending with batching
-- 🧪 **Well tested** - Comprehensive test suite
-- 📖 **CLI tool** - Command-line interface for quick operations
+- **Easy to use** - Simple, intuitive API
+- **Robust error handling** - Comprehensive exception handling and validation
+- **Phone number validation** - Built-in phone number validation and formatting
+- **Retry logic** - Automatic retry on failures with exponential backoff
+- **Logging support** - Detailed logging for debugging and monitoring
+- **Type hints** - Full type hint support for better IDE experience
+- **Security** - Secure credential handling
+- **Bulk SMS** - Efficient bulk SMS sending with batching
+- **Well tested** - Comprehensive test suite
+- **CLI tool** - Command-line interface for quick operations
 
 ## Installation
 
@@ -297,11 +297,19 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Support
 
-- 📧 Email: j1997ames@gmail.com
-- 🐛 Issues: [GitHub Issues](https://github.com/islandkid-20/beem-sms-python/issues)
-- 📖 Documentation: [Read the Docs](https://beem-sms-python.readthedocs.io/)
+- Email: j1997ames@gmail.com
+- Issues: [GitHub Issues](https://github.com/islandkid-20/beem-sms-python/issues)
+- Documentation: [Read the Docs](https://beem-sms-python.readthedocs.io/)
 
 ## Changelog
+
+
+### v1.0.2
+
+* Adjusted message length limits to support multi-part SMS:
+
+  * Increased `MAX_MESSAGE_LENGTH` from `160` to `153 * 3`
+  * Increased `MAX_UNICODE_LENGTH` from `70` to `67 * 3`
 
 ### v1.0.1
 

--- a/beem_sms/__init__.py
+++ b/beem_sms/__init__.py
@@ -4,7 +4,7 @@ Beem SMS Python SDK
 A professional Python package for sending SMS via Beem API.
 """
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 __author__ = "James Mashaka"
 __email__ = "j1997ames@gmail.com"
 

--- a/beem_sms/client.py
+++ b/beem_sms/client.py
@@ -56,8 +56,8 @@ class BeemSMSClient:
     """Professional Beem SMS client"""
 
     DEFAULT_BASE_URL = "https://apisms.beem.africa/v1/send"
-    MAX_MESSAGE_LENGTH = 160
-    MAX_UNICODE_LENGTH = 70
+    MAX_MESSAGE_LENGTH = 153 * 3
+    MAX_UNICODE_LENGTH = 67 * 3
     DEFAULT_TIMEOUT = 30
     MAX_RETRIES = 3
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ types-requests>=2.28.0
 pre-commit>=2.20
 sphinx>=5.0
 sphinx-rtd-theme>=1.0
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ else:
 
 setup(
     name="beem-sms-python",
-    version="1.0.1",
+    version="1.0.2",
     author="James Mashaka",
     author_email="j1997ames@gmail.com",
     description="Professional Python SDK for Beem SMS API",


### PR DESCRIPTION
- Increased `MAX_MESSAGE_LENGTH` from `160` to `153 * 3`
- Increased `MAX_UNICODE_LENGTH` from `70` to `67 * 3`

This change ensures compatibility with multipart SMS by accounting for segment headers.
